### PR TITLE
Calculate SAPUI5 Application Index from Grunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Optional in case options.ui5.package is set to '$TMP'.
 
 Defines the transport number which logs the changes. For the transport number it would also make sense to pass it via an argument.
 
+#### options.ui5.calc_appindex
+Type: `Boolean`
+Default: `false`
+
+Specify if you require the application index (program /UI5/APP_INDEX_CALCULATE) for the application to be recalculated after the BSP application is uploaded.
+Note: this only works on ADT version 1.30.x or higher (User Interface Add-On 2.0 for SAP NetWeaver).
+
 #### options.resources.cwd
 Type: `String`
 

--- a/tasks/nwabap_ui5uploader.js
+++ b/tasks/nwabap_ui5uploader.js
@@ -96,7 +96,8 @@ module.exports = function (grunt) {
                 transportno: oOptions.ui5.transportno,
                 package: oOptions.ui5.package,
                 bspcontainer: oOptions.ui5.bspcontainer,
-                bspcontainer_text: oOptions.ui5.bspcontainer_text
+                bspcontainer_text: oOptions.ui5.bspcontainer_text,
+                calc_appindex: !!oOptions.ui5.calc_appindex
             }
         };
 


### PR DESCRIPTION
Hi,

Firstly - thanks for this amazing tool, it is surely to cut down the development loop for future SAPUI5 applications on the ABAP stack!

I have User Interface Add-On 2.0 installed and this brings a program called /UI5/APP_INDEX_CALCULATE that is triggered automatically after every BSP is uploaded by program /UI5/UI5_REPOSITORY_LOAD to ensure the latest version is served to the client. This means you no longer need to visit program /UI2/INVALIDATE_CLIENT_CACHES to perform a costly invalidation of every application for every user, it will do it for only the application (and I believe files) that have changed.

I have added an option parameter to this grunt task (ui5.calc_appindex) to perform an additional POST request to ADT  to update the UI5 application index after it has synchronised the app files. I made it optional and off by default since the documentation states this is only supported in ADT 1.30.x+ and I didn't want to break anything running on lower versions.

The supporting documentation is here - http://help.sap.com/saphelp_uiaddon20/helpdata/en/c5/e7098474274d3eb7379047ab792f1f/content.htm.

Please let me know if you have any questions.

Thanks,

Oli