### PR TITLE
Create a new transport request on deployment. 

### DIFF
--- a/tasks/lib/adt_client.js
+++ b/tasks/lib/adt_client.js
@@ -1,0 +1,104 @@
+'use strict';
+
+var unirest = require('unirest');
+var util = require('./filestoreutil');
+var ADT_BASE_URL = '/sap/bc/adt/';
+
+
+/**
+ *
+ * @param {object} oConnection
+ * @param {string} oConnection.server
+ * @param {string} oConnection.client
+ * @param {boolean} oConnection.useStrictSSL
+ * @param {object} oAuth
+ * @param {string} oAuth.user
+ * @param {string} oAuth.pwd
+ * @param {string} [sLanguage]
+ * @param {Logger} [oLogger]
+ * @constructor
+ */
+function AdtClient(oConnection, oAuth, sLanguage, oLogger) {
+    this._oOptions = {
+        auth: oAuth,
+        conn: oConnection,
+        lang: sLanguage
+    };
+
+    this._oLogger = oLogger;
+}
+
+/**
+ * Construct the base Url for server access
+ * @private
+ * @return {string} base URL
+ */
+AdtClient.prototype._constructBaseUrl = function () {
+    return this._oOptions.conn.server + ADT_BASE_URL;
+};
+
+/**
+ * Determine a CSRF Token which is necessary for POST/PUT/DELETE operations; also the sapCookie is determined
+ * @private
+ * @param {function} fnCallback callback function
+ * @return {void}
+ */
+AdtClient.prototype._determineCSRFToken = function (fnCallback) {
+    if (this._sCSRFToken !== undefined) {
+        fnCallback();
+        return;
+    }
+
+    var oRequest = unirest.get(this.buildUrl(ADT_BASE_URL + 'discovery'));
+    oRequest.header('X-CSRF-Token', 'Fetch');
+    this.sendRequest(oRequest, function (oResponse) {
+        if (oResponse.statusCode === util.HTTPSTAT.ok) {
+            this._sCSRFToken = oResponse.headers['x-csrf-token'];
+            this._sSAPCookie = oResponse.headers['set-cookie'];
+        }
+        fnCallback(util.createResponseError(oResponse));
+    }.bind(this));
+};
+
+AdtClient.prototype.buildUrl = function (sUrl) {
+    return this._oOptions.conn.server + sUrl;
+};
+
+/**
+ * Send a request to the server (adds additional information before sending, e.g. authentication information)
+ * @param {unirest} oRequest Unirest request object
+ * @param {function} fnRequestCallback Callback for unirest request
+ */
+AdtClient.prototype.sendRequest = function (oRequest, fnRequestCallback) {
+    var me = this;
+
+    if (me._oOptions.auth) {
+        oRequest.auth({user: me._oOptions.auth.user, pass: me._oOptions.auth.pwd});
+    }
+
+    oRequest.strictSSL(me._oOptions.conn.useStrictSSL);
+
+    if (me._oOptions.conn.client) {
+        oRequest.query({
+            'sap-client': encodeURIComponent(me._oOptions.conn.client)
+        });
+    }
+
+    if (me._oOptions.lang) {
+        oRequest.query({
+            'sap-language': encodeURIComponent(me._oOptions.lang)
+        });
+    }
+
+    if (!oRequest.hasHeader('x-csrf-token') && this._sCSRFToken) {
+        oRequest.header('X-CSRF-Token', this._sCSRFToken);
+    }
+
+    if (!oRequest.hasHeader('cookie') && this._sSAPCookie) {
+        oRequest.header('Cookie', this._sSAPCookie);
+    }
+
+    oRequest.end(fnRequestCallback);
+};
+
+module.exports = AdtClient;

--- a/tasks/lib/transports.js
+++ b/tasks/lib/transports.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var util = require('util');
+var fsutil = require('./filestoreutil');
+var unirest = require('unirest');
+var CTS_BASE_URL = '/sap/bc/adt/cts/transports';
+var AdtClient = require('./adt_client');
+
+/**
+ * creates and releases transport requests
+ * @param {object}  oOptions
+ * @param {object}  oOptions.conn               connection info
+ * @param {string}  oOptions.conn.server        server url
+ * @param {string}  oOptions.conn.client        sap client id
+ * @param {boolean} oOptions.conn.useStrictSSL  force encrypted connection
+ * @param {string}  oOptions.auth.user          username
+ * @param {string}  oOptions.auth.pwd           password
+ * @param {Logger} oLogger
+ * @constructor
+ */
+function Transports(oOptions, oLogger) {
+    this.client = new AdtClient(oOptions.conn, oOptions.auth, undefined, oLogger);
+}
+
+
+Transports.prototype.createTransport = function (sPackageName, sRequestText, fnCallback) {
+    var sTemplate = '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">' +
+        '<asx:values>' +
+        '<DATA>' +
+        '<OPERATION>I</OPERATION>' +
+        '<DEVCLASS>%s</DEVCLASS>' +
+        '<REQUEST_TEXT>%s</REQUEST_TEXT>' +
+        '</DATA>' +
+        '</asx:values>' +
+        '</asx:abap>';
+
+    var sPayload = util.format(sTemplate, sPackageName, sRequestText);
+    var sUrl = this.client.buildUrl(CTS_BASE_URL);
+    this.client._determineCSRFToken(function (x) {
+        var sRequest = unirest('POST', sUrl, {}, sPayload);
+        this.client.sendRequest(sRequest, function (oResponse) {
+            if (oResponse.status === fsutil.HTTPSTAT.ok) {
+                fnCallback(null, oResponse.body.split('/').pop());
+                return;
+            }
+            fnCallback(new Error(fsutil.createResponseError(oResponse)));
+        });
+    }.bind(this));
+};
+
+module.exports = Transports;

--- a/tasks/nwabap_ui5uploader.js
+++ b/tasks/nwabap_ui5uploader.js
@@ -133,7 +133,7 @@ module.exports = function (grunt) {
             });
         }
 
-        if (oOptions.ui5.transportno === undefined && oOptions.ui5.create_transport === true) {
+        if (oOptions.ui5.package !== '$TMP' && oOptions.ui5.transportno === undefined && oOptions.ui5.create_transport === true) {
             var oTransportManager = new Transports(oFileStoreOptions, oLogger);
             oTransportManager.createTransport(oOptions.ui5.package, oOptions.ui5.transport_text, function (oError, sTransportNo) {
                 if (oError) {

--- a/tasks/nwabap_ui5uploader.js
+++ b/tasks/nwabap_ui5uploader.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var FileStore = require('./lib/filestore.js');
+var Transports = require('./lib/transports');
 var Logger = require('./lib/logger.js');
 
 module.exports = function (grunt) {
@@ -54,8 +55,14 @@ module.exports = function (grunt) {
             return;
         }
 
-        if (oOptions.ui5.package !== '$TMP' && !oOptions.ui5.transportno) {
+        if (oOptions.ui5.package !== '$TMP' && !oOptions.ui5.transportno && oOptions.ui5.create_transport !== true) {
             grunt.fail.warn('For packages <> "$TMP" a transport number is necessary.');
+            done();
+            return;
+        }
+
+        if (oOptions.ui5.create_transport === true && typeof oOptions.ui5.transport_text !== 'string') {
+            grunt.fail.warn('Please specifiy a description to be used for the created transport in create_transport.');
             done();
             return;
         }
@@ -104,16 +111,42 @@ module.exports = function (grunt) {
             }
         };
 
-        var oFileStore = new FileStore(oFileStoreOptions, new Logger(grunt));
+        var oLogger = new Logger(grunt);
 
-        oFileStore.syncFiles(aFiles, oOptions.resources.cwd, function (oError, aArtifactsSync) {
+        /**
+         *
+         * @param {object} oFileStoreOptions
+         * @param {object} oLogger
+         * @param {object} aFiles
+         * @param {object} oOptions
+         */
+        function syncFiles(oFileStoreOptions, oLogger, aFiles, oOptions) {
+            var oFileStore = new FileStore(oFileStoreOptions, oLogger);
 
-            if (oError) {
-                grunt.fail.warn(oError);
-            }
+            oFileStore.syncFiles(aFiles, oOptions.resources.cwd, function (oError, aArtifactsSync) {
 
-            done();
-        });
+                if (oError) {
+                    grunt.fail.warn(oError);
+                }
+
+                done();
+            });
+        }
+
+        if (oOptions.ui5.transportno === undefined && oOptions.ui5.create_transport === true) {
+            var oTransportManager = new Transports(oFileStoreOptions, oLogger);
+            oTransportManager.createTransport(oOptions.ui5.package, oOptions.ui5.transport_text, function (oError, sTransportNo) {
+                if (oError) {
+                    grunt.fail.error(oError);
+                    return done();
+                }
+
+                oFileStoreOptions.ui5.transportno = sTransportNo;
+                syncFiles(oFileStoreOptions, oLogger, aFiles, oOptions);
+            });
+        } else {
+            syncFiles(oFileStoreOptions, oLogger, aFiles, oOptions);
+        }
     });
 
 };


### PR DESCRIPTION
The user may want to create a new transport request for every deployment. 

I wan't able to figure out how to release a transport request yet, but I think it would make sense to add this feature also, so single deployment would create a self-contained complete transport request. 

This feature uses two new configuration parameters: 
 - boolean ui5.create_transport:  true => create request, false => don't
 - string ui5.transport_text: used as the description for the request. 

